### PR TITLE
Add Day of Week Filter to Grid View

### DIFF
--- a/src/hooks/use-filtered-events.jsx
+++ b/src/hooks/use-filtered-events.jsx
@@ -1,0 +1,33 @@
+import React, { useState, useEffect } from 'react';
+import scheduleData from '../data/schedule-2023.json';
+import { useFilter } from '../contexts/filter.context';
+import { groupByTime } from '../utility/group-by-time';
+import { getShouldIncludeDay } from '../utility/get-should-include-day';
+
+const data = groupByTime(scheduleData);
+
+function useFilteredEvents() {
+  const [filteredEvents, setFilteredEvents] = useState(data);
+  const { dayFilters } = useFilter();
+
+  useEffect(() => {
+    const areNoFilters = dayFilters.every(function ({ isActive }) {
+      return !isActive;
+    });
+
+    if (areNoFilters) {
+      setFilteredEvents(data);
+      return;
+    }
+
+    const remainingDates = data.filter(function ({ date }) {
+      return getShouldIncludeDay({ eventDate: date, dayFilters });
+    });
+
+    setFilteredEvents(remainingDates);
+  }, [data, dayFilters]);
+
+  return { filteredEvents };
+}
+
+export { useFilteredEvents };

--- a/src/pages/grid.jsx
+++ b/src/pages/grid.jsx
@@ -1,12 +1,11 @@
 import React, { useState } from 'react';
-import { findIndex, uniq } from 'ramda';
+import { uniq } from 'ramda';
 import Link from 'next/link';
 import GridRow from '../components/GridRow';
 import Modal from '../components/Modal';
-import { groupByTime } from '../utility/group-by-time';
+import DayFilters from '../components/DayFilters';
+import { useFilteredEvents } from '../hooks/use-filtered-events';
 import scheduleData from '../data/schedule-2023.json';
-
-const data = groupByTime(scheduleData);
 
 const locations = scheduleData.map(({ location }) => location);
 const allUniqueLocations = uniq(locations);
@@ -14,6 +13,7 @@ const allUniqueLocations = uniq(locations);
 const GridPage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalEvent, setModalEvent] = useState(null);
+  const { filteredEvents } = useFilteredEvents();
 
   function handleTitleClick(event) {
     setModalEvent(event);
@@ -35,6 +35,7 @@ const GridPage = () => {
       <p>
         <Link href="/">List View</Link>
       </p>
+      <DayFilters />
       <table>
         <thead>
           <tr>
@@ -45,7 +46,7 @@ const GridPage = () => {
           </tr>
         </thead>
         <tbody>
-          {data.map((d) => (
+          {filteredEvents.map((d) => (
             <GridRow
               data={d}
               key={d.date}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,45 +1,14 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import Link from 'next/link';
-import scheduleData from '../data/schedule-2023.json';
 import ListRow from '../components/ListRow';
 import Modal from '../components/Modal';
 import DayFilters from '../components/DayFilters';
-import { useFilter } from '../contexts/filter.context';
-import { groupByTime } from '../utility/group-by-time';
-
-const data = groupByTime(scheduleData);
-
-function getShouldIncludeDay({ dayFilters, eventDate }) {
-  const dayOfWeekIndex = eventDate.getDay();
-  const { isActive } = dayFilters.find(function ({ ofWeek }) {
-    return ofWeek === dayOfWeekIndex;
-  });
-
-  return isActive;
-}
+import { useFilteredEvents } from '../hooks/use-filtered-events';
 
 const IndexPage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalEvent, setModalEvent] = useState(null);
-  const [filteredEvents, setFilteredEvents] = useState(data);
-  const { dayFilters } = useFilter();
-
-  useEffect(() => {
-    const areNoFilters = dayFilters.every(function ({ isActive }) {
-      return !isActive;
-    });
-
-    if (areNoFilters) {
-      setFilteredEvents(data);
-      return;
-    }
-
-    const remainingDates = data.filter(function ({ date }) {
-      return getShouldIncludeDay({ eventDate: date, dayFilters });
-    });
-
-    setFilteredEvents(remainingDates);
-  }, [data, dayFilters]);
+  const { filteredEvents } = useFilteredEvents();
 
   function handleTitleClick(event) {
     setModalEvent(event);

--- a/src/utility/get-should-include-day.js
+++ b/src/utility/get-should-include-day.js
@@ -1,0 +1,10 @@
+function getShouldIncludeDay({ dayFilters, eventDate }) {
+  const dayOfWeekIndex = eventDate.getDay();
+  const { isActive } = dayFilters.find(function ({ ofWeek }) {
+    return ofWeek === dayOfWeekIndex;
+  });
+
+  return isActive;
+}
+
+export { getShouldIncludeDay };


### PR DESCRIPTION
This pull request adds the day of week filter to the grid view.

The logic to group events and filter by the day of week was abstracted to a hook to be used on both pages.