### PR TITLE
Attempt to Prevent Mobile Zoom on Search

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -134,17 +134,13 @@ a {
 
 input.search-input {
   color: #a9abaf;
-  border: 1px solid #ccc;
-}
-
-input.search-input {
   height: 1.5rem;
   width: 100%;
   display: inline;
   margin-bottom: -9px;
-  font-size: 13px;
-  -webkit-border-radius: 2px;
-  -moz-border-radius: 2px;
-  border-radius: 2px;
+  font-size: 1rem;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  border-radius: 3px;
   border: 1px solid #ccc;
 }


### PR DESCRIPTION
My understanding is that mobile devices will zoom when someone attempts to enter input on an input that has a font size less than 16px. This attempts to prevent that on the search bar by increasing the font size.